### PR TITLE
Refactor package globals into container struct

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -99,7 +99,7 @@ Commands:
     down       Roll back the version by 1
     redo       Re-run the latest migration
     status     Dump the migration status for the current DB
-    dbversion  Print the current version of the database
+    version    Print the current version of the database
     create     Creates a blank migration template
 `
 )

--- a/dialect.go
+++ b/dialect.go
@@ -13,12 +13,8 @@ type SqlDialect interface {
 	dbVersionQuery(db *sql.DB, name string) (*sql.Rows, error)
 }
 
-func (c *Client) GetDialect() SqlDialect {
-	return c.Dialect
-}
-
 func GetDialect() SqlDialect {
-	return globalGoose.GetDialect()
+	return globalGoose.Dialect
 }
 
 func (c *Client) SetDialect(d string) error {

--- a/dialect.go
+++ b/dialect.go
@@ -17,7 +17,7 @@ func GetDialect() SqlDialect {
 	return globalGoose.Dialect
 }
 
-func (c *Client) SetDialect(d string) error {
+func (c *client) SetDialect(d string) error {
 	switch d {
 	case "postgres":
 		c.Dialect = &PostgresDialect{}

--- a/dialect.go
+++ b/dialect.go
@@ -8,30 +8,36 @@ import (
 // SqlDialect abstracts the details of specific SQL dialects
 // for goose's few SQL specific statements
 type SqlDialect interface {
-	createVersionTableSql() string // sql string to create the goose_db_version table
-	insertVersionSql() string      // sql string to insert the initial version table row
-	dbVersionQuery(db *sql.DB) (*sql.Rows, error)
+	createVersionTableSql(name string) string // sql string to create the goose_db_version table
+	insertVersionSql(name string) string      // sql string to insert the initial version table row
+	dbVersionQuery(db *sql.DB, name string) (*sql.Rows, error)
 }
 
-var dialect SqlDialect = &PostgresDialect{}
+func (c *Client) GetDialect() SqlDialect {
+	return c.Dialect
+}
 
 func GetDialect() SqlDialect {
-	return dialect
+	return globalGoose.GetDialect()
 }
 
-func SetDialect(d string) error {
+func (c *Client) SetDialect(d string) error {
 	switch d {
 	case "postgres":
-		dialect = &PostgresDialect{}
+		c.Dialect = &PostgresDialect{}
 	case "mysql":
-		dialect = &MySqlDialect{}
+		c.Dialect = &MySqlDialect{}
 	case "sqlite3":
-		dialect = &Sqlite3Dialect{}
+		c.Dialect = &Sqlite3Dialect{}
 	default:
 		return fmt.Errorf("%q: unknown dialect", d)
 	}
 
 	return nil
+}
+
+func SetDialect(d string) error {
+	return globalGoose.SetDialect(d)
 }
 
 ////////////////////////////
@@ -40,8 +46,8 @@ func SetDialect(d string) error {
 
 type PostgresDialect struct{}
 
-func (pg PostgresDialect) createVersionTableSql() string {
-	return `CREATE TABLE goose_db_version (
+func (pg PostgresDialect) createVersionTableSql(name string) string {
+	return `CREATE TABLE ` + name + ` (
             	id serial NOT NULL,
                 version_id bigint NOT NULL,
                 is_applied boolean NOT NULL,
@@ -50,12 +56,12 @@ func (pg PostgresDialect) createVersionTableSql() string {
             );`
 }
 
-func (pg PostgresDialect) insertVersionSql() string {
-	return "INSERT INTO goose_db_version (version_id, is_applied) VALUES ($1, $2);"
+func (pg PostgresDialect) insertVersionSql(name string) string {
+	return "INSERT INTO " + name + " (version_id, is_applied) VALUES ($1, $2);"
 }
 
-func (pg PostgresDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query("SELECT version_id, is_applied from goose_db_version ORDER BY id DESC")
+func (pg PostgresDialect) dbVersionQuery(db *sql.DB, name string) (*sql.Rows, error) {
+	rows, err := db.Query("SELECT version_id, is_applied from " + name + " ORDER BY id DESC")
 	if err != nil {
 		return nil, err
 	}
@@ -69,8 +75,8 @@ func (pg PostgresDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
 
 type MySqlDialect struct{}
 
-func (m MySqlDialect) createVersionTableSql() string {
-	return `CREATE TABLE goose_db_version (
+func (m MySqlDialect) createVersionTableSql(name string) string {
+	return `CREATE TABLE ` + name + ` (
                 id serial NOT NULL,
                 version_id bigint NOT NULL,
                 is_applied boolean NOT NULL,
@@ -79,12 +85,12 @@ func (m MySqlDialect) createVersionTableSql() string {
             );`
 }
 
-func (m MySqlDialect) insertVersionSql() string {
-	return "INSERT INTO goose_db_version (version_id, is_applied) VALUES (?, ?);"
+func (m MySqlDialect) insertVersionSql(name string) string {
+	return "INSERT INTO " + name + " (version_id, is_applied) VALUES (?, ?);"
 }
 
-func (m MySqlDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query("SELECT version_id, is_applied from goose_db_version ORDER BY id DESC")
+func (m MySqlDialect) dbVersionQuery(db *sql.DB, name string) (*sql.Rows, error) {
+	rows, err := db.Query("SELECT version_id, is_applied from " + name + " ORDER BY id DESC")
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +104,8 @@ func (m MySqlDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
 
 type Sqlite3Dialect struct{}
 
-func (m Sqlite3Dialect) createVersionTableSql() string {
-	return `CREATE TABLE goose_db_version (
+func (m Sqlite3Dialect) createVersionTableSql(name string) string {
+	return `CREATE TABLE ` + name + ` (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 version_id INTEGER NOT NULL,
                 is_applied INTEGER NOT NULL,
@@ -107,12 +113,12 @@ func (m Sqlite3Dialect) createVersionTableSql() string {
             );`
 }
 
-func (m Sqlite3Dialect) insertVersionSql() string {
-	return "INSERT INTO goose_db_version (version_id, is_applied) VALUES (?, ?);"
+func (m Sqlite3Dialect) insertVersionSql(name string) string {
+	return "INSERT INTO " + name + " (version_id, is_applied) VALUES (?, ?);"
 }
 
-func (m Sqlite3Dialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query("SELECT version_id, is_applied from goose_db_version ORDER BY id DESC")
+func (m Sqlite3Dialect) dbVersionQuery(db *sql.DB, name string) (*sql.Rows, error) {
+	rows, err := db.Query("SELECT version_id, is_applied from " + name + " ORDER BY id DESC")
 	if err != nil {
 		return nil, err
 	}

--- a/down.go
+++ b/down.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-func (c *Client) Down(db *sql.DB, dir string) error {
+func (c *client) Down(db *sql.DB, dir string) error {
 	currentVersion, err := c.GetDBVersion(db)
 	if err != nil {
 		return err

--- a/down.go
+++ b/down.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 )
 
-func Down(db *sql.DB, dir string) error {
+func (g *Goose) Down(db *sql.DB, dir string) error {
 	currentVersion, err := GetDBVersion(db)
 	if err != nil {
 		return err
 	}
 
-	migrations, err := collectMigrations(dir, minVersion, maxVersion)
+	migrations, err := g.collectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}

--- a/down.go
+++ b/down.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 )
 
-func (g *Goose) Down(db *sql.DB, dir string) error {
-	currentVersion, err := GetDBVersion(db)
+func (c *Client) Down(db *sql.DB, dir string) error {
+	currentVersion, err := c.GetDBVersion(db)
 	if err != nil {
 		return err
 	}
 
-	migrations, err := g.collectMigrations(dir, minVersion, maxVersion)
+	migrations, err := c.collectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}
@@ -21,5 +21,5 @@ func (g *Goose) Down(db *sql.DB, dir string) error {
 		return fmt.Errorf("no migration %v", currentVersion)
 	}
 
-	return current.Down(db)
+	return c.runMigration(db, current, migrateDown)
 }

--- a/example/migrations-go/cmd/main.go
+++ b/example/migrations-go/cmd/main.go
@@ -87,6 +87,6 @@ Commands:
     down       Roll back the version by 1
     redo       Re-run the latest migration
     status     Dump the migration status for the current DB
-    dbversion  Print the current version of the database
+    version    Print the current version of the database
 `
 )

--- a/goose.go
+++ b/goose.go
@@ -6,15 +6,21 @@ import (
 )
 
 var (
-	goose      = Client{}
 	minVersion = int64(0)
 	maxVersion = int64((1 << 63) - 1)
 )
 
-type Client struct {
+type client struct {
 	TableName  string
-	Migrations Migrations
 	Dialect    SqlDialect
+	migrations Migrations
+}
+
+func New(tableName string, dialect SqlDialect) *client {
+	return &client{
+		TableName: tableName,
+		Dialect:   dialect,
+	}
 }
 
 func Run(command string, db *sql.DB, dir string, args ...string) error {

--- a/goose.go
+++ b/goose.go
@@ -6,13 +6,15 @@ import (
 )
 
 var (
-	goose      = Goose{}
+	goose      = Client{}
 	minVersion = int64(0)
 	maxVersion = int64((1 << 63) - 1)
 )
 
-type Goose struct {
+type Client struct {
+	TableName  string
 	Migrations Migrations
+	Dialect    SqlDialect
 }
 
 func Run(command string, db *sql.DB, dir string, args ...string) error {
@@ -50,7 +52,7 @@ func Run(command string, db *sql.DB, dir string, args ...string) error {
 			return err
 		}
 	case "version":
-		if err := Version(db, dir); err != nil {
+		if err := globalGoose.Version(db, dir); err != nil {
 			return err
 		}
 	default:

--- a/goose.go
+++ b/goose.go
@@ -3,23 +3,26 @@ package goose
 import (
 	"database/sql"
 	"fmt"
-	"sync"
 )
 
 var (
-	duplicateCheckOnce sync.Once
-	minVersion         = int64(0)
-	maxVersion         = int64((1 << 63) - 1)
+	goose      = Goose{}
+	minVersion = int64(0)
+	maxVersion = int64((1 << 63) - 1)
 )
+
+type Goose struct {
+	Migrations Migrations
+}
 
 func Run(command string, db *sql.DB, dir string, args ...string) error {
 	switch command {
 	case "up":
-		if err := Up(db, dir); err != nil {
+		if err := globalGoose.Up(db, dir); err != nil {
 			return err
 		}
 	case "up-by-one":
-		if err := UpByOne(db, dir); err != nil {
+		if err := globalGoose.UpByOne(db, dir); err != nil {
 			return err
 		}
 	case "create":
@@ -35,15 +38,15 @@ func Run(command string, db *sql.DB, dir string, args ...string) error {
 			return err
 		}
 	case "down":
-		if err := Down(db, dir); err != nil {
+		if err := globalGoose.Down(db, dir); err != nil {
 			return err
 		}
 	case "redo":
-		if err := Redo(db, dir); err != nil {
+		if err := globalGoose.Redo(db, dir); err != nil {
 			return err
 		}
 	case "status":
-		if err := Status(db, dir); err != nil {
+		if err := globalGoose.Status(db, dir); err != nil {
 			return err
 		}
 	case "version":

--- a/migrate.go
+++ b/migrate.go
@@ -14,7 +14,7 @@ var (
 	ErrNoCurrentVersion = errors.New("no current version found")
 	ErrNoNextVersion    = errors.New("no next version found")
 
-	globalGoose = &Client{
+	globalGoose = &client{
 		TableName: "goose_db_version",
 		Dialect:   &PostgresDialect{},
 	}
@@ -69,12 +69,12 @@ func (ms Migrations) String() string {
 }
 
 // AddMigration adds a new go migration to the goose struct.
-func (c *Client) AddMigration(up func(*sql.Tx) error, down func(*sql.Tx) error) {
+func (c *client) AddMigration(up func(*sql.Tx) error, down func(*sql.Tx) error) {
 	_, filename, _, _ := runtime.Caller(1)
 	v, _ := NumericComponent(filename)
 	migration := &Migration{Version: v, Next: -1, Previous: -1, UpFn: up, DownFn: down, Source: filename}
 
-	c.Migrations = append(c.Migrations, migration)
+	c.migrations = append(c.migrations, migration)
 }
 
 // AddMigration exists for legacy support of the package global use of Goose.
@@ -86,12 +86,12 @@ func AddMigration(up func(*sql.Tx) error, down func(*sql.Tx) error) {
 	v, _ := NumericComponent(filename)
 	migration := &Migration{Version: v, Next: -1, Previous: -1, UpFn: up, DownFn: down, Source: filename}
 
-	globalGoose.Migrations = append(globalGoose.Migrations, migration)
+	globalGoose.migrations = append(globalGoose.migrations, migration)
 }
 
 // collect all the valid looking migration scripts in the
 // migrations folder and go func registry, and key them by version
-func (c *Client) collectMigrations(dirpath string, current, target int64) (Migrations, error) {
+func (c *client) collectMigrations(dirpath string, current, target int64) (Migrations, error) {
 	var migrations Migrations
 
 	// extract the numeric component of each migration,
@@ -113,7 +113,7 @@ func (c *Client) collectMigrations(dirpath string, current, target int64) (Migra
 		}
 	}
 
-	for _, migration := range c.Migrations {
+	for _, migration := range c.migrations {
 		v, err := NumericComponent(migration.Source)
 		if err != nil {
 			return nil, err
@@ -160,7 +160,7 @@ func versionFilter(v, current, target int64) bool {
 
 // retrieve the current version for this DB.
 // Create and initialize the DB version table if it doesn't exist.
-func (c *Client) GetDBVersion(db *sql.DB) (int64, error) {
+func (c *client) GetDBVersion(db *sql.DB) (int64, error) {
 
 	rows, err := c.Dialect.dbVersionQuery(db, c.TableName)
 	if err != nil {
@@ -207,7 +207,7 @@ func (c *Client) GetDBVersion(db *sql.DB) (int64, error) {
 
 // Create the goose_db_version table
 // and insert the initial 0 value into it
-func (c *Client) createVersionTable(db *sql.DB) error {
+func (c *client) createVersionTable(db *sql.DB) error {
 	txn, err := db.Begin()
 	if err != nil {
 		return err

--- a/migrate.go
+++ b/migrate.go
@@ -160,9 +160,9 @@ func versionFilter(v, current, target int64) bool {
 
 // retrieve the current version for this DB.
 // Create and initialize the DB version table if it doesn't exist.
-func (c *Client) EnsureDBVersion(db *sql.DB) (int64, error) {
+func (c *Client) GetDBVersion(db *sql.DB) (int64, error) {
 
-	rows, err := c.GetDialect().dbVersionQuery(db, c.TableName)
+	rows, err := c.Dialect.dbVersionQuery(db, c.TableName)
 	if err != nil {
 		return 0, c.createVersionTable(db)
 	}
@@ -213,7 +213,7 @@ func (c *Client) createVersionTable(db *sql.DB) error {
 		return err
 	}
 
-	d := c.GetDialect()
+	d := c.Dialect
 
 	if _, err := txn.Exec(d.createVersionTableSql(c.TableName)); err != nil {
 		txn.Rollback()
@@ -228,15 +228,4 @@ func (c *Client) createVersionTable(db *sql.DB) error {
 	}
 
 	return txn.Commit()
-}
-
-// wrapper for EnsureDBVersion for callers that don't already have
-// their own DB instance
-func (c *Client) GetDBVersion(db *sql.DB) (int64, error) {
-	version, err := c.EnsureDBVersion(db)
-	if err != nil {
-		return -1, err
-	}
-
-	return version, nil
 }

--- a/migrate.go
+++ b/migrate.go
@@ -14,7 +14,10 @@ var (
 	ErrNoCurrentVersion = errors.New("no current version found")
 	ErrNoNextVersion    = errors.New("no next version found")
 
-	globalGoose = &Goose{}
+	globalGoose = &Client{
+		TableName: "goose_db_version",
+		Dialect:   &PostgresDialect{},
+	}
 )
 
 type Migrations []*Migration
@@ -66,12 +69,12 @@ func (ms Migrations) String() string {
 }
 
 // AddMigration adds a new go migration to the goose struct.
-func (g *Goose) AddMigration(up func(*sql.Tx) error, down func(*sql.Tx) error) {
+func (c *Client) AddMigration(up func(*sql.Tx) error, down func(*sql.Tx) error) {
 	_, filename, _, _ := runtime.Caller(1)
 	v, _ := NumericComponent(filename)
 	migration := &Migration{Version: v, Next: -1, Previous: -1, UpFn: up, DownFn: down, Source: filename}
 
-	g.Migrations = append(g.Migrations, migration)
+	c.Migrations = append(c.Migrations, migration)
 }
 
 // AddMigration exists for legacy support of the package global use of Goose.
@@ -88,7 +91,7 @@ func AddMigration(up func(*sql.Tx) error, down func(*sql.Tx) error) {
 
 // collect all the valid looking migration scripts in the
 // migrations folder and go func registry, and key them by version
-func (g *Goose) collectMigrations(dirpath string, current, target int64) (Migrations, error) {
+func (c *Client) collectMigrations(dirpath string, current, target int64) (Migrations, error) {
 	var migrations Migrations
 
 	// extract the numeric component of each migration,
@@ -110,7 +113,7 @@ func (g *Goose) collectMigrations(dirpath string, current, target int64) (Migrat
 		}
 	}
 
-	for _, migration := range g.Migrations {
+	for _, migration := range c.Migrations {
 		v, err := NumericComponent(migration.Source)
 		if err != nil {
 			return nil, err
@@ -157,11 +160,11 @@ func versionFilter(v, current, target int64) bool {
 
 // retrieve the current version for this DB.
 // Create and initialize the DB version table if it doesn't exist.
-func EnsureDBVersion(db *sql.DB) (int64, error) {
+func (c *Client) EnsureDBVersion(db *sql.DB) (int64, error) {
 
-	rows, err := GetDialect().dbVersionQuery(db)
+	rows, err := c.GetDialect().dbVersionQuery(db, c.TableName)
 	if err != nil {
-		return 0, createVersionTable(db)
+		return 0, c.createVersionTable(db)
 	}
 	defer rows.Close()
 
@@ -204,22 +207,22 @@ func EnsureDBVersion(db *sql.DB) (int64, error) {
 
 // Create the goose_db_version table
 // and insert the initial 0 value into it
-func createVersionTable(db *sql.DB) error {
+func (c *Client) createVersionTable(db *sql.DB) error {
 	txn, err := db.Begin()
 	if err != nil {
 		return err
 	}
 
-	d := GetDialect()
+	d := c.GetDialect()
 
-	if _, err := txn.Exec(d.createVersionTableSql()); err != nil {
+	if _, err := txn.Exec(d.createVersionTableSql(c.TableName)); err != nil {
 		txn.Rollback()
 		return err
 	}
 
 	version := 0
 	applied := true
-	if _, err := txn.Exec(d.insertVersionSql(), version, applied); err != nil {
+	if _, err := txn.Exec(d.insertVersionSql(c.TableName), version, applied); err != nil {
 		txn.Rollback()
 		return err
 	}
@@ -229,8 +232,8 @@ func createVersionTable(db *sql.DB) error {
 
 // wrapper for EnsureDBVersion for callers that don't already have
 // their own DB instance
-func GetDBVersion(db *sql.DB) (int64, error) {
-	version, err := EnsureDBVersion(db)
+func (c *Client) GetDBVersion(db *sql.DB) (int64, error) {
+	version, err := c.EnsureDBVersion(db)
 	if err != nil {
 		return -1, err
 	}

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -1,8 +1,6 @@
 package goose
 
-import (
-	"testing"
-)
+import "testing"
 
 func newMigration(v int64, src string) *Migration {
 	return &Migration{Version: v, Previous: -1, Next: -1, Source: src}

--- a/migration.go
+++ b/migration.go
@@ -38,7 +38,7 @@ func (m *Migration) String() string {
 	return fmt.Sprintf(m.Source)
 }
 
-func (c *Client) runMigration(db *sql.DB, m *Migration, direction bool) error {
+func (c *client) runMigration(db *sql.DB, m *Migration, direction bool) error {
 	switch filepath.Ext(m.Source) {
 	case ".sql":
 		if err := c.runSQLMigration(db, m.Source, m.Version, direction); err != nil {
@@ -120,7 +120,7 @@ func CreateMigration(name, migrationType, dir string, t time.Time) (path string,
 
 // Update the version table for the given migration,
 // and finalize the transaction.
-func (c *Client) FinalizeMigration(tx *sql.Tx, direction bool, v int64) error {
+func (c *client) FinalizeMigration(tx *sql.Tx, direction bool, v int64) error {
 
 	// XXX: drop goose_db_version table on some minimum version number?
 	stmt := c.Dialect.insertVersionSql(c.TableName)

--- a/migration.go
+++ b/migration.go
@@ -123,7 +123,7 @@ func CreateMigration(name, migrationType, dir string, t time.Time) (path string,
 func (c *Client) FinalizeMigration(tx *sql.Tx, direction bool, v int64) error {
 
 	// XXX: drop goose_db_version table on some minimum version number?
-	stmt := c.GetDialect().insertVersionSql(c.TableName)
+	stmt := c.Dialect.insertVersionSql(c.TableName)
 	if _, err := tx.Exec(stmt, v, direction); err != nil {
 		tx.Rollback()
 		return err

--- a/migration_sql.go
+++ b/migration_sql.go
@@ -135,7 +135,7 @@ func splitSQLStatements(r io.Reader, direction bool) (stmts []string) {
 //
 // All statements following an Up or Down directive are grouped together
 // until another direction directive is found.
-func (c *Client) runSQLMigration(db *sql.DB, scriptFile string, v int64, direction bool) error {
+func (c *client) runSQLMigration(db *sql.DB, scriptFile string, v int64, direction bool) error {
 
 	tx, err := db.Begin()
 	if err != nil {

--- a/migration_sql.go
+++ b/migration_sql.go
@@ -135,7 +135,7 @@ func splitSQLStatements(r io.Reader, direction bool) (stmts []string) {
 //
 // All statements following an Up or Down directive are grouped together
 // until another direction directive is found.
-func runSQLMigration(db *sql.DB, scriptFile string, v int64, direction bool) error {
+func (c *Client) runSQLMigration(db *sql.DB, scriptFile string, v int64, direction bool) error {
 
 	tx, err := db.Begin()
 	if err != nil {
@@ -160,7 +160,7 @@ func runSQLMigration(db *sql.DB, scriptFile string, v int64, direction bool) err
 		}
 	}
 
-	if err = FinalizeMigration(tx, direction, v); err != nil {
+	if err = c.FinalizeMigration(tx, direction, v); err != nil {
 		log.Fatalf("error finalizing migration %s, quitting. (%v)", filepath.Base(scriptFile), err)
 	}
 

--- a/redo.go
+++ b/redo.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 )
 
-func (c *Client) Redo(db *sql.DB, dir string) error {
+func (c *client) Redo(db *sql.DB, dir string) error {
 	currentVersion, err := c.GetDBVersion(db)
 	if err != nil {
 		return err

--- a/redo.go
+++ b/redo.go
@@ -4,13 +4,13 @@ import (
 	"database/sql"
 )
 
-func Redo(db *sql.DB, dir string) error {
+func (g *Goose) Redo(db *sql.DB, dir string) error {
 	currentVersion, err := GetDBVersion(db)
 	if err != nil {
 		return err
 	}
 
-	migrations, err := collectMigrations(dir, minVersion, maxVersion)
+	migrations, err := g.collectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}

--- a/redo.go
+++ b/redo.go
@@ -4,13 +4,13 @@ import (
 	"database/sql"
 )
 
-func (g *Goose) Redo(db *sql.DB, dir string) error {
-	currentVersion, err := GetDBVersion(db)
+func (c *Client) Redo(db *sql.DB, dir string) error {
+	currentVersion, err := c.GetDBVersion(db)
 	if err != nil {
 		return err
 	}
 
-	migrations, err := g.collectMigrations(dir, minVersion, maxVersion)
+	migrations, err := c.collectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}
@@ -25,11 +25,11 @@ func (g *Goose) Redo(db *sql.DB, dir string) error {
 		return err
 	}
 
-	if err := previous.Up(db); err != nil {
+	if err := c.runMigration(db, previous, migrateUp); err != nil {
 		return err
 	}
 
-	if err := current.Up(db); err != nil {
+	if err := c.runMigration(db, current, migrateUp); err != nil {
 		return err
 	}
 

--- a/status.go
+++ b/status.go
@@ -16,7 +16,7 @@ func (c *Client) Status(db *sql.DB, dir string) error {
 	}
 
 	// must ensure that the version table exists if we're running on a pristine DB
-	if _, err := c.EnsureDBVersion(db); err != nil {
+	if _, err := c.GetDBVersion(db); err != nil {
 		return err
 	}
 

--- a/status.go
+++ b/status.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func (c *Client) Status(db *sql.DB, dir string) error {
+func (c *client) Status(db *sql.DB, dir string) error {
 	// collect all migrations
 	migrations, err := c.collectMigrations(dir, minVersion, maxVersion)
 	if err != nil {

--- a/status.go
+++ b/status.go
@@ -8,15 +8,15 @@ import (
 	"time"
 )
 
-func (g *Goose) Status(db *sql.DB, dir string) error {
+func (c *Client) Status(db *sql.DB, dir string) error {
 	// collect all migrations
-	migrations, err := g.collectMigrations(dir, minVersion, maxVersion)
+	migrations, err := c.collectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}
 
 	// must ensure that the version table exists if we're running on a pristine DB
-	if _, err := EnsureDBVersion(db); err != nil {
+	if _, err := c.EnsureDBVersion(db); err != nil {
 		return err
 	}
 

--- a/status.go
+++ b/status.go
@@ -8,9 +8,9 @@ import (
 	"time"
 )
 
-func Status(db *sql.DB, dir string) error {
+func (g *Goose) Status(db *sql.DB, dir string) error {
 	// collect all migrations
-	migrations, err := collectMigrations(dir, minVersion, maxVersion)
+	migrations, err := g.collectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}

--- a/up.go
+++ b/up.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-func (c *Client) Up(db *sql.DB, dir string) error {
+func (c *client) Up(db *sql.DB, dir string) error {
 	migrations, err := c.collectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
@@ -34,7 +34,7 @@ func (c *Client) Up(db *sql.DB, dir string) error {
 	return nil
 }
 
-func (c *Client) UpByOne(db *sql.DB, dir string) error {
+func (c *client) UpByOne(db *sql.DB, dir string) error {
 	migrations, err := c.collectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err

--- a/up.go
+++ b/up.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 )
 
-func Up(db *sql.DB, dir string) error {
-	migrations, err := collectMigrations(dir, minVersion, maxVersion)
+func (g *Goose) Up(db *sql.DB, dir string) error {
+	migrations, err := g.collectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}
@@ -34,8 +34,8 @@ func Up(db *sql.DB, dir string) error {
 	return nil
 }
 
-func UpByOne(db *sql.DB, dir string) error {
-	migrations, err := collectMigrations(dir, minVersion, maxVersion)
+func (g *Goose) UpByOne(db *sql.DB, dir string) error {
+	migrations, err := g.collectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}

--- a/up.go
+++ b/up.go
@@ -6,6 +6,7 @@ import (
 )
 
 func (g *Goose) Up(db *sql.DB, dir string) error {
+	fmt.Println("up")
 	migrations, err := g.collectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
@@ -14,6 +15,7 @@ func (g *Goose) Up(db *sql.DB, dir string) error {
 	for {
 		current, err := GetDBVersion(db)
 		if err != nil {
+			fmt.Println("err getting version: ", err)
 			return err
 		}
 
@@ -27,6 +29,7 @@ func (g *Goose) Up(db *sql.DB, dir string) error {
 		}
 
 		if err = next.Up(db); err != nil {
+			fmt.Println("err running: ", err)
 			return err
 		}
 	}

--- a/up.go
+++ b/up.go
@@ -5,17 +5,15 @@ import (
 	"fmt"
 )
 
-func (g *Goose) Up(db *sql.DB, dir string) error {
-	fmt.Println("up")
-	migrations, err := g.collectMigrations(dir, minVersion, maxVersion)
+func (c *Client) Up(db *sql.DB, dir string) error {
+	migrations, err := c.collectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}
 
 	for {
-		current, err := GetDBVersion(db)
+		current, err := c.GetDBVersion(db)
 		if err != nil {
-			fmt.Println("err getting version: ", err)
 			return err
 		}
 
@@ -28,8 +26,7 @@ func (g *Goose) Up(db *sql.DB, dir string) error {
 			return err
 		}
 
-		if err = next.Up(db); err != nil {
-			fmt.Println("err running: ", err)
+		if err = c.runMigration(db, next, migrateUp); err != nil {
 			return err
 		}
 	}
@@ -37,13 +34,13 @@ func (g *Goose) Up(db *sql.DB, dir string) error {
 	return nil
 }
 
-func (g *Goose) UpByOne(db *sql.DB, dir string) error {
-	migrations, err := g.collectMigrations(dir, minVersion, maxVersion)
+func (c *Client) UpByOne(db *sql.DB, dir string) error {
+	migrations, err := c.collectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}
 
-	currentVersion, err := GetDBVersion(db)
+	currentVersion, err := c.GetDBVersion(db)
 	if err != nil {
 		return err
 	}
@@ -56,7 +53,7 @@ func (g *Goose) UpByOne(db *sql.DB, dir string) error {
 		return err
 	}
 
-	if err = next.Up(db); err != nil {
+	if err = c.runMigration(db, next, migrateUp); err != nil {
 		return err
 	}
 

--- a/version.go
+++ b/version.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-func (c *Client) Version(db *sql.DB, dir string) error {
+func (c *client) Version(db *sql.DB, dir string) error {
 	current, err := c.GetDBVersion(db)
 	if err != nil {
 		return err

--- a/version.go
+++ b/version.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 )
 
-func Version(db *sql.DB, dir string) error {
-	current, err := GetDBVersion(db)
+func (c *Client) Version(db *sql.DB, dir string) error {
+	current, err := c.GetDBVersion(db)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR attempts to eliminate globals in the Goose package, instead introducing goose.Client as a container for the data that was previously stored in globals. Existing methods are refactored to use a single global instance of this struct.

One of the advantages of this approach is the ability to define separate database tables to track migrations separately for creating tables and populating data.

There is also cleanup of typos and dead code.